### PR TITLE
Inertia View path might be different

### DIFF
--- a/src/InertiaResponseRenderer.php
+++ b/src/InertiaResponseRenderer.php
@@ -4,12 +4,10 @@ namespace Arcanist;
 
 use Inertia\Inertia;
 use Illuminate\Support\Str;
-use Illuminate\Support\Facades\File;
 use Arcanist\Contracts\ResponseRenderer;
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Contracts\Support\Responsable;
 use Symfony\Component\HttpFoundation\Response;
-use Arcanist\Exception\StepTemplateNotFoundException;
 
 class InertiaResponseRenderer implements ResponseRenderer
 {
@@ -23,11 +21,6 @@ class InertiaResponseRenderer implements ResponseRenderer
         array $data = []
     ): Response | Responsable | Renderable {
         $component = $this->componentBasePath . '/' . Str::studly($wizard::$slug) . '/' . Str::studly($step->slug);
-        $componentPath = resource_path('js/Pages/' . $component . '.vue');
-
-        if (!File::exists($componentPath)) {
-            throw new StepTemplateNotFoundException($step);
-        }
 
         $viewData = [
             'arcanist' => array_filter([

--- a/tests/InertiaResponseRendererTest.php
+++ b/tests/InertiaResponseRendererTest.php
@@ -145,20 +145,6 @@ class InertiaResponseRendererTest extends TestCase
         $response->assertSessionHasErrors('wizard');
     }
 
-    /** @test */
-    public function it_throws_an_exception_if_the_template_does_not_exist(): void
-    {
-        File::shouldReceive('exists')
-            ->with(resource_path('js/Pages/Wizards/InertiaWizard/InertiaStep.vue'))
-            ->andReturnFalse();
-
-        $this->expectException(StepTemplateNotFoundException::class);
-        $this->expectErrorMessage('No template found for step [inertia-step].');
-
-        $this->makeRenderer()
-            ->renderStep($this->step, $this->wizard, []);
-    }
-
     protected function makeRenderer(): ResponseRenderer
     {
         return new InertiaResponseRenderer('Wizards');


### PR DESCRIPTION
The view path for Inertia pages might be different in some projects. The default path according to the Inertia documentation is `ressources/js/Pages`. However as a developer I could change it to whatever I like. Even moving the Pages folder to a completely different place.

```js
createInertiaApp({
  resolve: name => require(`./Madness/${name}`),
  // ...
})
```

Therefore it is not possible for Laravel to check if a component exists.